### PR TITLE
Remove panel styling from Table

### DIFF
--- a/src/Table/Table.scss
+++ b/src/Table/Table.scss
@@ -1,6 +1,4 @@
 table.table {
-  border-radius: 4px;
-  box-shadow: 0px 6px 15px rgba(194, 194, 194, 0.5);
   width: 100%;
   border-collapse: collapse;
   font-size: 14px;


### PR DESCRIPTION
Wrap `<Table>` in a `<Panel>` without padding to get the same styling as before. This removes the redundancy between Panel and Table, and allows users to add elements before or after the Table in the same panel.